### PR TITLE
Add Banned items feature to fix Trim Duplication bug

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -234,9 +234,9 @@ local get_first_normal_recipe = function(stack)
                 end
             end
         end
+        local item_stack_string = stack:to_string()
         -- fallback, passtrough if no recipes found or is a banned item.
         if not found or is_item_banned(item_stack_string, banned_items_array) then
-            local item_stack_string = stack:to_string()
             
             -- Process for banned items
             local tmp3 = {}

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -15,3 +15,5 @@ k_recyclebin.recycle_cursed (Recycle Cursed Items [mineclonia mostly]) bool fals
 # Basically, the higher the number the more chaotic the output when the ingredients are an `Any` type
 # Because of the way lua tables work, there's no guarantee of which item is discovered at runtime.
 k_recyclebin.group_item_mapping_sample_size (Group To Item Mapping Sample Size) int 1 1 256
+
+k_recyclebin.banned_items (Banned Items) string mcl_armor:sentry,mcl_armor:dune,mcl_armor:coast,mcl_armor:wild,mcl_armor:tide,mcl_armor:ward,mcl_armor:vex,rib,mcl_armor:snout,mcl_armor:eye,mcl_armor:spire,mcl_armor:silence,mcl_armor:wayfinder


### PR DESCRIPTION
There is an issue where if you put armor trims in mineclone2, in the recycler. it  allows you to get infinate diamonds as it returns the trim back to you, plus some diamonds. which can be used as a dupe bug.

This PR adds a `banned_items` setting where admins can specify items that will just pass through the recycler, unchanged, if its a banned item.

This fixes a bug in mineclone2 and also adds a new feature, two birds one stone. :)